### PR TITLE
chore: bump dependencies, cheminfo metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,24 +39,45 @@
     "trailingComma": "all"
   },
   "devDependencies": {
-    "@babel/plugin-transform-modules-commonjs": "^7.12.13",
-    "@types/jest": "^26.0.20",
-    "cheminfo-build": "^1.1.9",
-    "eslint": "^7.20.0",
-    "eslint-config-cheminfo": "^5.2.2",
+    "@babel/plugin-transform-modules-commonjs": "^7.13.8",
+    "@types/jest": "^26.0.22",
+    "cheminfo-build": "^1.1.10",
+    "eslint": "^7.24.0",
+    "eslint-config-cheminfo": "^5.2.3",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jest": "^24.1.5",
-    "eslint-plugin-prettier": "^3.3.1",
+    "eslint-plugin-jest": "^24.3.5",
+    "eslint-plugin-prettier": "^3.4.0",
     "jest": "^26.6.3",
     "papaparse": "^5.3.0",
     "prettier": "^2.2.1",
-    "rollup": "^2.39.0"
+    "rollup": "^2.45.2"
   },
   "dependencies": {
-    "common-spectrum": "0.20.0",
+    "common-spectrum": "0.31.0",
     "convert-to-jcamp": "^4.2.0",
-    "jcampconverter": "^7.7.0",
-    "ml-gsd": "^6.6.0",
+    "jcampconverter": "^7.8.0",
+    "ml-gsd": "^6.6.1",
     "vamas": "^0.0.3"
+  },
+  "info": {
+    "logo": "https://raw.githubusercontent.com/cheminfo/font/master/src/misc/cristal2.svg",
+    "domain": [
+      "Physical Chemistry",
+      "Materials Science"
+    ],
+    "technique": {
+      "name": "XPS",
+      "chmo": "0000404",
+      "iupac": "https://doi.org/10.1351/goldbook.X06716"
+    },
+    "functionality": {
+      "fileTypes": [
+        {
+          "extension": "vms",
+          "manufacturer": "ISO 14976",
+          "example": "https://raw.githubusercontent.com/cheminfo/xps-analysis/master/testFiles/assigned.vms"
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
updated version of [`d100342` (#2)](https://github.com/cheminfo/xps-analysis/pull/2/commits/d1003420e1594a5f69db8a0411fbc8aeba96457d)